### PR TITLE
Improve search form layout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -170,3 +170,5 @@ static/js/relevant.js.map
 static/js/mermaid.min.js
 static/js/trials.js
 static/js/trials.js.map
+nginx-production-settings/
+nginx-prod

--- a/assets/js/components/SearchApp.jsx
+++ b/assets/js/components/SearchApp.jsx
@@ -557,7 +557,7 @@ function SearchApp() {
                       <div className="input-group-append">
                         <button
                           type="submit"
-                          className="btn btn-primary btn-lg search-button"
+                          className="btn btn-primary search-button"
                           disabled={isLoading}
                         >
                           {isLoading ? (

--- a/assets/js/components/SearchApp.jsx
+++ b/assets/js/components/SearchApp.jsx
@@ -423,7 +423,7 @@ function SearchApp() {
       <div className="article-results">        
         {renderPagination('articles')}
         
-        <div className="list-group article-list mx-auto">
+        <div className="list-group article-list d-flex justify-content-center flex-wrap">
           {articleResults.map((article) => (
             <ArticleListItem
               key={String(article.article_id)}
@@ -449,7 +449,7 @@ function SearchApp() {
       <div className="trial-results">        
         {renderPagination('trials')}
         
-        <div className="list-group article-list mx-auto">
+        <div className="list-group article-list d-flex justify-content-center flex-wrap">
           {trialResults.map((trial) => (
             <TrialListItem
               key={trial.id || trial.trial_id || trial.nct_id || Math.random().toString(36)}
@@ -510,41 +510,43 @@ function SearchApp() {
   };
   
   return (
-    <div className="search-app container mx-auto">
+    <div className="search-app container mt-5">
       {/* Search Form Container - Centered */}
       <div className="row justify-content-center">
         <div className="col-lg-8">
           {/* Search Form Card */}
           <div className="card mb-4">
             <div className="card-header bg-light">
-              <h3 className="mb-0 text-primary text-center">Search GregoryMS Database</h3>
+              <h3 className="mb-0 text-primary">Search GregoryMS Database</h3>
             </div>
             <div className="card-body">
               <form onSubmit={handleSearch}>
-                <div className="form-row align-items-end">
-                  <div className="form-group col-md-6 mb-3">
-                    <label htmlFor="searchType" className="col-form-label">Search Type</label>
-                    <select
-                      className="form-control"
-                      id="searchType"
-                      value={searchType}
-                      onChange={(e) => {
-                        setSearchType(e.target.value);
-                        // Update active tab to match search type
-                        setActiveTab(e.target.value);
-                      }}
-                    >
-                      {SEARCH_TYPE_OPTIONS.map(option => (
-                        <option key={option.value} value={option.value}>
-                          {option.label}
-                        </option>
-                      ))}
-                    </select>
+                <div className="row">
+                  <div className="col-md-4 mb-3">
+                    <div className="form-group">
+                      <label htmlFor="searchType">Search Type</label>
+                      <select 
+                        className="form-control"
+                        id="searchType"
+                        value={searchType}
+                        onChange={(e) => {
+                          setSearchType(e.target.value);
+                          // Update active tab to match search type
+                          setActiveTab(e.target.value);
+                        }}
+                      >
+                        {SEARCH_TYPE_OPTIONS.map(option => (
+                          <option key={option.value} value={option.value}>
+                            {option.label}
+                          </option>
+                        ))}
+                      </select>
+                    </div>
                   </div>
-
-                  <div className="form-group col-md-6 mb-3">
-                    <label htmlFor="searchTerm" className="col-form-label">Search Terms</label>
-                    <div className="input-group search-input-group">
+                  
+                  <div className="col-md-8 mb-3">
+                    <div className="form-group">
+                      <label htmlFor="searchTerm">Search Terms</label>
                       <input
                         type="text"
                         className="form-control"
@@ -554,48 +556,32 @@ function SearchApp() {
                         onChange={(e) => setSearchTerm(e.target.value)}
                         required
                       />
-                      <div className="input-group-append">
-                        <button
-                          type="submit"
-                          className="btn btn-primary search-button"
-                          disabled={isLoading}
-                        >
-                          {isLoading ? (
-                            <>
-                              <span className="spinner-border spinner-border-sm mr-2" role="status" aria-hidden="true"></span>
-                              Searching...
-                            </>
-                          ) : (
-                            <>
-                              <i className="fas fa-search mr-2"></i>
-                              Search {searchType === 'articles' ? 'Articles' : 'Clinical Trials'}
-                            </>
-                          )}
-                        </button>
-                      </div>
                     </div>
                   </div>
                 </div>
             
-                <div className="form-row">
-                  <div className="form-group col-md-6 mb-3">
-                    <label htmlFor="searchField">Search In</label>
-                    <select
-                      className="form-control"
-                      id="searchField"
-                      value={searchField}
-                      onChange={(e) => setSearchField(e.target.value)}
-                    >
-                      <option value="all">All Fields</option>
-                      <option value="title">Title Only</option>
-                      <option value="summary">Abstract/Summary Only</option>
-                    </select>
+                <div className="row">
+                  <div className="col-md-6 mb-3">
+                    <div className="form-group">
+                      <label htmlFor="searchField">Search In</label>
+                      <select 
+                        className="form-control"
+                        id="searchField"
+                        value={searchField}
+                        onChange={(e) => setSearchField(e.target.value)}
+                      >
+                        <option value="all">All Fields</option>
+                        <option value="title">Title Only</option>
+                        <option value="summary">Abstract/Summary Only</option>
+                      </select>
+                    </div>
                   </div>
-
-                    {searchType === 'trials' && (
-                      <div className="form-group col-md-6 mb-3">
+                  
+                  {searchType === 'trials' && (
+                    <div className="col-md-6 mb-3">
+                      <div className="form-group">
                         <label htmlFor="trialStatus">Trial Status</label>
-                        <select
+                        <select 
                           className="form-control"
                           id="trialStatus"
                           value={trialStatus}
@@ -608,17 +594,38 @@ function SearchApp() {
                           ))}
                         </select>
                       </div>
+                    </div>
+                  )}
+                </div>
+            
+                <div className="text-center">
+                  <button 
+                    type="submit" 
+                    className="btn btn-primary btn-lg"
+                    disabled={isLoading}
+                  >
+                    {isLoading ? (
+                      <>
+                        <span className="spinner-border spinner-border-sm mr-2" role="status" aria-hidden="true"></span>
+                        Searching...
+                      </>
+                    ) : (
+                      <>
+                        <i className="fas fa-search mr-2"></i>
+                        Search {searchType === 'articles' ? 'Articles' : 'Clinical Trials'}
+                      </>
                     )}
-                  </div>
-                </form>
+                  </button>
+                </div>
+              </form>
             </div>
           </div>
         </div>
       </div>
       
       {/* Search Results */}
-      <div className="row justify-content-center">
-        <div className="col-lg-11">
+      <div className="d-flex justify-content-center">
+        <div className="col-lg-10 mx-auto">
           {renderResults()}
         </div>
       </div>

--- a/assets/js/components/SearchApp.jsx
+++ b/assets/js/components/SearchApp.jsx
@@ -510,43 +510,41 @@ function SearchApp() {
   };
   
   return (
-    <div className="search-app container mt-5">
+    <div className="search-app container mx-auto">
       {/* Search Form Container - Centered */}
       <div className="row justify-content-center">
         <div className="col-lg-8">
           {/* Search Form Card */}
           <div className="card mb-4">
             <div className="card-header bg-light">
-              <h3 className="mb-0 text-primary">Search GregoryMS Database</h3>
+              <h3 className="mb-0 text-primary text-center">Search GregoryMS Database</h3>
             </div>
             <div className="card-body">
               <form onSubmit={handleSearch}>
-                <div className="row">
-                  <div className="col-md-4 mb-3">
-                    <div className="form-group">
-                      <label htmlFor="searchType">Search Type</label>
-                      <select 
-                        className="form-control"
-                        id="searchType"
-                        value={searchType}
-                        onChange={(e) => {
-                          setSearchType(e.target.value);
-                          // Update active tab to match search type
-                          setActiveTab(e.target.value);
-                        }}
-                      >
-                        {SEARCH_TYPE_OPTIONS.map(option => (
-                          <option key={option.value} value={option.value}>
-                            {option.label}
-                          </option>
-                        ))}
-                      </select>
-                    </div>
+                <div className="form-row align-items-end">
+                  <div className="form-group col-md-4 mb-3">
+                    <label htmlFor="searchType" className="col-form-label">Search Type</label>
+                    <select
+                      className="form-control"
+                      id="searchType"
+                      value={searchType}
+                      onChange={(e) => {
+                        setSearchType(e.target.value);
+                        // Update active tab to match search type
+                        setActiveTab(e.target.value);
+                      }}
+                    >
+                      {SEARCH_TYPE_OPTIONS.map(option => (
+                        <option key={option.value} value={option.value}>
+                          {option.label}
+                        </option>
+                      ))}
+                    </select>
                   </div>
-                  
-                  <div className="col-md-8 mb-3">
-                    <div className="form-group">
-                      <label htmlFor="searchTerm">Search Terms</label>
+
+                  <div className="form-group col-md-8 mb-3">
+                    <label htmlFor="searchTerm" className="col-form-label">Search Terms</label>
+                    <div className="input-group search-input-group">
                       <input
                         type="text"
                         className="form-control"
@@ -556,32 +554,48 @@ function SearchApp() {
                         onChange={(e) => setSearchTerm(e.target.value)}
                         required
                       />
+                      <div className="input-group-append">
+                        <button
+                          type="submit"
+                          className="btn btn-primary btn-lg search-button"
+                          disabled={isLoading}
+                        >
+                          {isLoading ? (
+                            <>
+                              <span className="spinner-border spinner-border-sm mr-2" role="status" aria-hidden="true"></span>
+                              Searching...
+                            </>
+                          ) : (
+                            <>
+                              <i className="fas fa-search mr-2"></i>
+                              Search {searchType === 'articles' ? 'Articles' : 'Clinical Trials'}
+                            </>
+                          )}
+                        </button>
+                      </div>
                     </div>
                   </div>
                 </div>
             
-                <div className="row">
-                  <div className="col-md-6 mb-3">
-                    <div className="form-group">
-                      <label htmlFor="searchField">Search In</label>
-                      <select 
-                        className="form-control"
-                        id="searchField"
-                        value={searchField}
-                        onChange={(e) => setSearchField(e.target.value)}
-                      >
-                        <option value="all">All Fields</option>
-                        <option value="title">Title Only</option>
-                        <option value="summary">Abstract/Summary Only</option>
-                      </select>
-                    </div>
+                <div className="form-row">
+                  <div className="form-group col-md-6 mb-3">
+                    <label htmlFor="searchField">Search In</label>
+                    <select
+                      className="form-control"
+                      id="searchField"
+                      value={searchField}
+                      onChange={(e) => setSearchField(e.target.value)}
+                    >
+                      <option value="all">All Fields</option>
+                      <option value="title">Title Only</option>
+                      <option value="summary">Abstract/Summary Only</option>
+                    </select>
                   </div>
-                  
-                  {searchType === 'trials' && (
-                    <div className="col-md-6 mb-3">
-                      <div className="form-group">
+
+                    {searchType === 'trials' && (
+                      <div className="form-group col-md-6 mb-3">
                         <label htmlFor="trialStatus">Trial Status</label>
-                        <select 
+                        <select
                           className="form-control"
                           id="trialStatus"
                           value={trialStatus}
@@ -594,30 +608,9 @@ function SearchApp() {
                           ))}
                         </select>
                       </div>
-                    </div>
-                  )}
-                </div>
-            
-                <div className="text-center">
-                  <button 
-                    type="submit" 
-                    className="btn btn-primary btn-lg"
-                    disabled={isLoading}
-                  >
-                    {isLoading ? (
-                      <>
-                        <span className="spinner-border spinner-border-sm mr-2" role="status" aria-hidden="true"></span>
-                        Searching...
-                      </>
-                    ) : (
-                      <>
-                        <i className="fas fa-search mr-2"></i>
-                        Search {searchType === 'articles' ? 'Articles' : 'Clinical Trials'}
-                      </>
                     )}
-                  </button>
-                </div>
-              </form>
+                  </div>
+                </form>
             </div>
           </div>
         </div>

--- a/assets/js/components/SearchApp.jsx
+++ b/assets/js/components/SearchApp.jsx
@@ -423,7 +423,7 @@ function SearchApp() {
       <div className="article-results">        
         {renderPagination('articles')}
         
-        <div className="list-group article-list">
+        <div className="list-group article-list mx-auto">
           {articleResults.map((article) => (
             <ArticleListItem
               key={String(article.article_id)}
@@ -449,7 +449,7 @@ function SearchApp() {
       <div className="trial-results">        
         {renderPagination('trials')}
         
-        <div className="list-group article-list">
+        <div className="list-group article-list mx-auto">
           {trialResults.map((trial) => (
             <TrialListItem
               key={trial.id || trial.trial_id || trial.nct_id || Math.random().toString(36)}
@@ -522,7 +522,7 @@ function SearchApp() {
             <div className="card-body">
               <form onSubmit={handleSearch}>
                 <div className="form-row align-items-end">
-                  <div className="form-group col-md-4 mb-3">
+                  <div className="form-group col-md-6 mb-3">
                     <label htmlFor="searchType" className="col-form-label">Search Type</label>
                     <select
                       className="form-control"
@@ -542,7 +542,7 @@ function SearchApp() {
                     </select>
                   </div>
 
-                  <div className="form-group col-md-8 mb-3">
+                  <div className="form-group col-md-6 mb-3">
                     <label htmlFor="searchTerm" className="col-form-label">Search Terms</label>
                     <div className="input-group search-input-group">
                       <input
@@ -618,7 +618,7 @@ function SearchApp() {
       
       {/* Search Results */}
       <div className="row justify-content-center">
-        <div className="col-lg-10">
+        <div className="col-lg-11">
           {renderResults()}
         </div>
       </div>

--- a/assets/scss/gregory-custom.scss
+++ b/assets/scss/gregory-custom.scss
@@ -5,6 +5,8 @@
 @import "article-list.scss";
 
 .search-app {
+  margin: 3rem auto;
+  padding: 0 1rem;
   .card {
     border-radius: 0.5rem;
     box-shadow: 0 4px 8px rgba(0, 0, 0, 0.05);
@@ -36,5 +38,13 @@
     &:last-child {
       border-bottom: none;
     }
+  }
+
+  .search-input-group {
+    margin-bottom: 1rem;
+  }
+
+  .search-button {
+    min-width: 10rem;
   }
 }

--- a/assets/scss/gregory-custom.scss
+++ b/assets/scss/gregory-custom.scss
@@ -5,7 +5,7 @@
 @import "article-list.scss";
 
 .search-app {
-  margin: 3rem auto;
+  margin: 5rem auto;
   padding: 0 1rem;
   .card {
     border-radius: 0.5rem;
@@ -45,6 +45,6 @@
   }
 
   .search-button {
-    min-width: 10rem;
+    min-width: 8rem;
   }
 }

--- a/assets/scss/gregory-custom.scss
+++ b/assets/scss/gregory-custom.scss
@@ -45,6 +45,6 @@
   }
 
   .search-button {
-    min-width: 8rem;
+    // use default width for better alignment
   }
 }

--- a/layouts/shortcodes/search.html
+++ b/layouts/shortcodes/search.html
@@ -1,4 +1,4 @@
-<div id="search-root"></div>
+<div class="col-12" id="search-root"></div>
 
 <script>
 // Define fallback utility functions in global scope to avoid undefined errors


### PR DESCRIPTION
## Summary
- center the search page container and header text
- consolidate form elements using Bootstrap input groups
- style the page via updated SCSS

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run build:jsx` *(fails: Cannot find module 'esbuild')*

------
https://chatgpt.com/codex/tasks/task_e_686189128918832488f1f3732bdbf843